### PR TITLE
Refact: remove animation

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,23 +6,58 @@
 
 (function() {
   'use strict';
-  const deleteHoveredMessage = () => {
-    const actionsBtn = document.querySelector('ts-message:hover button[data-action="actions_menu"]')
-    if (!actionsBtn) return
-    actionsBtn.click()
-    const deleteBtn = document.querySelector('li#delete_link a')
-    if (!deleteBtn) return
-    deleteBtn.click()
-    const okBtn = document.querySelector('button.btn.dialog_go.btn_danger')
-    if (!okBtn) return
-    okBtn.click()
-  }
+  const _x_id = () => `${window.boot_data.version_uid.substring(0, 8)}-${(new Date).getTime()/1000.0}`
 
-  const keyUp = e => {
-    // Control + Shift + Space
-    if (e.ctrlKey && e.shiftKey && e.keyCode == '32') {
-      deleteHoveredMessage()
+  // Limit is in ms
+  const throttle = (callback, limit = 100) => {
+    var wait = false
+    return function() { // We return a throttled function
+      if (!wait) {
+        callback.call()
+        wait = true // Prevent future invocations for a time
+        setTimeout(function() {
+          wait = false
+        }, limit)
+      }
     }
   }
-  document.addEventListener('keyup', keyUp, false)
+
+  const queryString = obj => {
+    var str = [];
+    for (var p in obj)
+      if (obj.hasOwnProperty(p)) {
+        str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]))
+      }
+    return str.join('&')
+  }
+
+  const deleteHoveredMessage = () => {
+    const el = document.querySelector('ts-message:hover')
+    el.style.display = "none"
+    const ts = el.getAttribute('data-ts')
+    const channel = el.getAttribute('data-model-ob-id')
+    const token = window.boot_data.api_token
+    const url = `https://${window.location.host}/api/chat.delete?_x_id=${_x_id()}`
+    const params = queryString({
+      channel,
+      token,
+      ts
+    })
+
+    const http = new XMLHttpRequest()
+    http.open("POST", url, true)
+    http.setRequestHeader("Content-type", "application/x-www-form-urlencoded")
+    http.send(params)
+  }
+
+  const throttledDelete = throttle(deleteHoveredMessage)
+
+  const handleKeyUp = e => {
+    // Shift + Backspace
+    if (e.shiftKey && e.keyCode === 8) {
+      throttledDelete()
+    }
+  }
+
+  document.addEventListener('keyup', handleKeyUp, false)
 })();

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,16 @@
+
+/**
+* injectScript - Inject internal script to available access to the `window`
+*
+* @param  {type} file_path Local path of the internal script.
+* @param  {type} tag The tag as string, where the script will be append (default: 'body').
+* @see    {@link http://stackoverflow.com/questions/20499994/access-window-variable-from-content-script}
+*/
+function injectScript(file_path, tag) {
+  var node = document.getElementsByTagName(tag)[0]
+  var script = document.createElement('script')
+  script.setAttribute('type', 'text/javascript')
+  script.setAttribute('src', file_path)
+  node.appendChild(script)
+}
+injectScript(chrome.extension.getURL('index.js'), 'body')

--- a/manifest.json
+++ b/manifest.json
@@ -1,22 +1,31 @@
 {
-    "manifest_version": 2,
-    "content_scripts": [ {
-        "exclude_globs":    [  ],
-        "include_globs":    [ "*" ],
-        "js":               [ "index.js" ],
-        "matches":          [
-          "https://*.slack.com/*",
-          "http://*.slack.com/*"
-        ],
-        "run_at": "document_end"
-    } ],
-    "converted_from_user_script": true,
-    "description":  "Use Control+Shift+Space delete the message under the cursor.",
-    "name":         "Slack Easy Delete",
-    "version":      "4",
-    "icons": {
-      "16": "icon16.png",
-      "48": "icon48.png",
-      "128": "icon128.png"
+  "manifest_version": 2,
+  "content_scripts": [
+    {
+      "exclude_globs": [],
+      "include_globs": [
+        "*"
+      ],
+      "js": [
+        "inject.js"
+      ],
+      "matches": [
+        "https://*.slack.com/messages/*",
+        "http://*.slack.com/messages/*"
+      ],
+      "run_at": "document_end"
     }
+  ],
+  "web_accessible_resources": [
+    "index.js"
+  ],
+  "converted_from_user_script": true,
+  "description": "Use Shift+Space delete the message under the cursor.",
+  "name": "Slack Easy Delete",
+  "version": "1",
+  "icons": {
+    "16": "icon16.png",
+    "48": "icon48.png",
+    "128": "icon128.png"
+  }
 }


### PR DESCRIPTION
- Does it directly through a `POST`
- Hides the message immediately
- Throttles just in case (100ms)

Still uses Shift+Backspace, but you can change that in your branch